### PR TITLE
chore: ignore Python for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,6 @@
   "extends": [
     "config:recommended"
   ],
-  "rangeStrategy": "bump"
+  "rangeStrategy": "bump",
+  "ignoreDeps": ["python"]
 }


### PR DESCRIPTION
Python version is controlled by what Debian and other OSes ship
