### PR TITLE
fix: ignore SBOM

### DIFF
--- a/src/Mybox/Package/Release/Internal.hs
+++ b/src/Mybox/Package/Release/Internal.hs
@@ -147,7 +147,7 @@ release p =
 
 environmentFilters :: Architecture -> OS -> [Text -> Bool]
 environmentFilters arch os = execWriter $ do
-  tell $ map excludes_ [".asc", ".sig", "sha256", "sha512", ".yml"]
+  tell $ map excludes_ [".asc", ".sig", "sha256", "sha512", "sbom", ".yml"]
   tell $ map excludes_ [".deb", ".rpm", ".dmg", ".exe", ".appimage"]
   tell $ osFilters os
   tell $ architectureFilters arch

--- a/test/Mybox/Package/ShellSpec.hs
+++ b/test/Mybox/Package/ShellSpec.hs
@@ -1,5 +1,7 @@
 module Mybox.Package.ShellSpec where
 
+import Data.Text qualified as Text
+
 import Mybox.Driver
 import Mybox.Driver.Test
 import Mybox.Package.Class
@@ -57,7 +59,8 @@ spec = do
           let package = shPackage{root}
           version <- localVersion package
           version `shouldSatisfy` isJust
-          fromJust version `shouldContainText` "sh"
+          -- root shell might be disabled
+          fromJust version `shouldSatisfy` (\v -> "sh" `Text.isInfixOf` v || "false" `Text.isInfixOf` v)
       it "fails on unexpected output" $ do
         let brokenGetShell :: Args -> Maybe Text
             brokenGetShell ("getent" :| _) = Just "unexpected output"

--- a/test/Mybox/Package/SystemSpec.hs
+++ b/test/Mybox/Package/SystemSpec.hs
@@ -29,7 +29,7 @@ spec = do
             ("alacritty" :| ["--version"])
             "alacritty 0"
     onlyIfOS "RPM is only available on Fedora" (\case Linux Fedora -> True; _ -> False) $ do
-      let fedoraVersion = "43" -- renovate: datasource=endoflife-date depName=fedora versioning=loose
+      let fedoraVersion = "44" -- renovate: datasource=endoflife-date depName=fedora versioning=loose
       packageSpec $
         ps ((mkSystemPackage "rpmfusion-free-release"){url = Just ("https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-" <> fedoraVersion <> ".noarch.rpm")})
           & checkInstalledCommandOutput


### PR DESCRIPTION
Exclude artifacts matching `sbom` from candidates for the Release package.