### PR TITLE
Fix npm scoped packages binary naming

### DIFF
--- a/src/Mybox/Package/NPM/Internal.hs
+++ b/src/Mybox/Package/NPM/Internal.hs
@@ -1,6 +1,7 @@
 module Mybox.Package.NPM.Internal where
 
 import Data.Map qualified as Map
+import Data.Set qualified as Set
 import Data.Text qualified as Text
 
 import Mybox.Aeson
@@ -50,13 +51,20 @@ viewVersion p = do
   prerequisites
   drvRunOutput $ "npm" :| ["view", p.package, "version"]
 
-newtype PackageJsonBin = PackageJsonBin {bin :: Either () (Map Text Text)} deriving (Eq, Show)
+newtype PackageJsonBin = PackageJsonBin {bin :: Either () (Set Text)} deriving (Eq, Show)
 
 instance FromJSON PackageJsonBin where
   parseJSON = withObject "PackageJsonBin" $ \obj -> do
     binEither :: Maybe (CollapsedEither Text (Map Text Text)) <- obj .:? "bin"
-    let bin = fromMaybe (Right mempty) $ fmap (first (const ()) . getCollapsedEither) binEither
+    let bin = case fmap getCollapsedEither binEither of
+          Just (Left _) -> Left ()
+          Just (Right bins) -> Right $ Map.keysSet bins
+          Nothing -> Right mempty
     pure $ PackageJsonBin{bin}
+
+binariesFromPackageJson :: NPMPackage -> PackageJsonBin -> Set Text
+binariesFromPackageJson p packageJson =
+  either (const $ Set.singleton $ Text.takeWhileEnd (/= '/') p.package) id packageJson.bin
 
 npmInstall :: App es => NPMPackage -> Eff es ()
 npmInstall p = do
@@ -84,7 +92,7 @@ npmInstall p = do
 
       packageJsonText <- drvReadFile (npxPath </> "node_modules" <//> mkPath @Rel p.package </> "package.json")
       packageJson <- jsonDecode @PackageJsonBin "package.json" packageJsonText
-      let binaries = either (const [p.package]) Map.keys $ packageJson.bin
+      let binaries = binariesFromPackageJson p packageJson
 
       forM_ binaries $ \name -> do
         let target = binDir </> name

--- a/test/Mybox/Package/NPMSpec.hs
+++ b/test/Mybox/Package/NPMSpec.hs
@@ -1,6 +1,6 @@
 module Mybox.Package.NPMSpec where
 
-import Data.Map qualified as Map
+import Data.Set qualified as Set
 
 import Mybox.Aeson
 import Mybox.Package.Class
@@ -47,13 +47,13 @@ spec = do
           ("kilo" :| ["help"])
           "show token usage"
         & ignorePaths (npmPaths <> [".local" </> "share" </> "kilo", ".local" </> "state" </> "kilo"])
-  describe "PackageJson" $ do
+  describe "PackageJsonBin" $ do
     it "parses bin field" $ do
       let json = "{\"bin\": {\"foo\": \"bar\"}}"
       let resultE = jsonDecode "example" json
       resultE `shouldSatisfy` isRight
       let pkg = requireRight resultE
-      pkg `shouldBe` PackageJsonBin (Right (Map.singleton "foo" "bar"))
+      pkg `shouldBe` PackageJsonBin (Right (Set.singleton "foo"))
     it "parses raw string" $ do
       let json = "{\"bin\": \"foo\"}"
       let resultE = jsonDecode "example" json
@@ -65,4 +65,15 @@ spec = do
       let resultE = jsonDecode "example" json
       resultE `shouldSatisfy` isRight
       let pkg = requireRight resultE
-      pkg `shouldBe` PackageJsonBin (Right Map.empty)
+      pkg `shouldBe` PackageJsonBin (Right mempty)
+  describe "binary naming" $ do
+    let unscoped = mkNPMPackage "foo"
+    let scoped = mkNPMPackage "@foo/bar"
+    let singleBin = PackageJsonBin (Left ())
+    let multiBin = PackageJsonBin (Right (Set.singleton "baz"))
+    it "uses package name for non-scoped package when bin is raw string" $ do
+      binariesFromPackageJson unscoped singleBin `shouldBe` Set.singleton "foo"
+    it "uses package basename for scoped package when bin is raw string" $ do
+      binariesFromPackageJson scoped singleBin `shouldBe` Set.singleton "bar"
+    it "uses map keys when bin is object" $ do
+      binariesFromPackageJson scoped multiBin `shouldBe` Set.singleton "baz"


### PR DESCRIPTION
## Summary
- fix npm binary name derivation when `package.json` has `bin` as a raw string
- use only the package basename so scoped packages install executable names like `bar` for `@foo/bar`
- add spec coverage for scoped/unscoped string `bin` and map-based `bin`

## Test plan
- [x] stack test --ta "--match basename"
- [x] stack test --ta "--match Mybox.Package.NPMSpec"